### PR TITLE
msm8974: enable USB OTG Settings

### DIFF
--- a/msm8974.mk
+++ b/msm8974.mk
@@ -122,6 +122,10 @@ PRODUCT_PROPERTY_OVERRIDES += \
 PRODUCT_PACKAGES += \
     thermanager
 
+# USB OTG
+PRODUCT_PROPERTY_OVERRIDES += \
+    persist.sys.isUsbOtgEnabled=true
+
 # Wifi
 PRODUCT_PROPERTY_OVERRIDES += \
     wifi.interface=wlan0 \


### PR DESCRIPTION
without this the menu for interact with OTG is hidden

Change-Id: I5fbb09a9014dba001b07cbe24fc303569567487c
Signed-off-by: David Viteri <davidteri91@gmail.com>